### PR TITLE
Fix broken url

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,4 +34,4 @@ cd Math18
 git pull
 ```
 
-A more detailed introductory tutorial for using Git can be found [here](http://jmausolf.github.io/code/Intro_Git/).
+A more detailed introductory tutorial for using Git can be found [here](http://jmausolf.github.io/code/intro_git/).


### PR DESCRIPTION
It seems that the author simply changed the case of the file name. Apologies for the dual PR (see also https://github.com/justingrimmer/MathCamp/pull/1#issue-213595029)--I realized after the fact that Math18 was the latest iteration. The two PRs fix the exact same url in the same way.